### PR TITLE
Install APCu stable version

### DIFF
--- a/debian-lamp.sh
+++ b/debian-lamp.sh
@@ -18,7 +18,7 @@ apt-get install mysql-server mysql-client apache2 php5 php5-cli libapache2-mod-p
 
 #Zend OpCache and APCu
 #printf "\n" | pecl install ZendOpcache-beta
-printf "\n" | pecl install apcu-beta
+printf "\n" | pecl install apcu
 
 #Finding absolute path to opcache.so location on Debian
 #OPCODE_EXTENSION_VAR=$(find / -name opcache.so)


### PR DESCRIPTION
APCu is now shipped on two channels, beta and stable.

The beta version is for PHP 7, the stable version PHP 5.3+.
